### PR TITLE
Fix voip

### DIFF
--- a/msm7x27a.mk
+++ b/msm7x27a.mk
@@ -169,5 +169,12 @@ PRODUCT_PROPERTY_OVERRIDES += \
    media.stagefright.enable-fma2dp=true \
    media.stagefright.enable-aac=true \
    media.stagefright.enable-qcp=true
+   
+# Voip
+PRODUCT_PROPERTY_OVERRIDES += \
+   lpa.decode=false
+   tunnel.decode=false
+   lpa.use-stagefright=false
+   lpa.releaselock=false
 
 $(call inherit-product, vendor/huawei/msm7x27a-common/msm7x27a-common-vendor.mk)


### PR DESCRIPTION
Voip call's dont work.. but delete the LPA profile in audio_policy.conf fix voip call's with all apps

Another easy way.. add this lines

lpa.decode=false
tunnel.decode=false
lpa.use-stagefright=false
lpa.releaselock=false

With this lines added, the voip calls work (withouth delete lpa profile in audio_policy) in 8000 and 16000 rates, also with "voip in" and "voip out" in MONO (no stereo), in stereo there are interference (bad).
